### PR TITLE
Feature/breadcrumbs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/net6.0/HelloBlake.Web.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/HelloBlake.Web.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/HelloBlake.Web.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/HelloBlake.Web.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Controllers/PageComponents.cs
+++ b/Controllers/PageComponents.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HelloBlake.Web.Controllers
+{
+    public class PageComponents : Controller
+    {
+        private readonly List<string> nodeTypeAliases;
+
+        public PageComponents()
+        {
+            nodeTypeAliases = new List<string> { "blockFolder", "utilityFolder", "contentFolder", "altLink", "xmlSitemap" };
+        }
+
+        public bool IsNodeTypeAlias(string contentTypeAlias)
+        {
+            return nodeTypeAliases.Contains(contentTypeAlias, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Views/Partials/_Breadcrumbs.cshtml
+++ b/Views/Partials/_Breadcrumbs.cshtml
@@ -1,13 +1,14 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @using Umbraco.Cms.Core.Routing
 @using Umbraco.Extensions
+@using HelloBlake.Web.Controllers
 @inject IPublishedUrlProvider PublishedUrlProvider
 
 @{
-    bool hideBreadcrumbs = Model.Value<bool>("hideBreadcrumbs");
+    PageComponents pc = new PageComponents();
     var selection = Model?.Ancestors().ToArray();
 
-    if (!hideBreadcrumbs && selection?.Length > 0)
+    if (selection?.Length > 0)
     {
         var items = selection.OrderBy(x => x.Level);
 
@@ -19,12 +20,7 @@
                             <ol class="breadcrumb">
                                 @foreach (var item in items)
                                 {
-                                    bool itemHidden = item.Value<bool>("umbracoNaviHide");
-                                    if (itemHidden)
-                                    {
-                                        continue;
-                                    }
-                                    if (!item.ContentType.Alias.ToLower().Contains("folder"))
+                                    if (!pc.IsNodeTypeAlias(item.ContentType.Alias))
                                     {
                                         <li class="breadcrumb-item">
                                             <a href="@item.Url(PublishedUrlProvider)">@item.Name</a>

--- a/uSync/v9/ContentTypes/contentfolder.config
+++ b/uSync/v9/ContentTypes/contentfolder.config
@@ -19,7 +19,9 @@
     <DefaultTemplate></DefaultTemplate>
     <AllowedTemplates />
   </Info>
-  <Structure />
+  <Structure>
+    <ContentType Key="4dfde993-bdd9-4d0d-8ed4-eed6f8fe5b33" SortOrder="0">contentPage</ContentType>
+  </Structure>
   <GenericProperties />
   <Tabs />
 </ContentType>

--- a/uSync/v9/ContentTypes/pagesettingscomposition.config
+++ b/uSync/v9/ContentTypes/pagesettingscomposition.config
@@ -22,22 +22,6 @@
   <Structure />
   <GenericProperties>
     <GenericProperty>
-      <Key>9e037e08-79aa-4eaf-85b4-ea2533ddf696</Key>
-      <Name>Hide Breadcrumbs</Name>
-      <Alias>hideBreadcrumbs</Alias>
-      <Definition>1ef91628-cb2d-4825-8ee1-3a06f1928d4e</Definition>
-      <Type>Umbraco.TrueFalse</Type>
-      <Mandatory>false</Mandatory>
-      <Validation></Validation>
-      <Description><![CDATA[]]></Description>
-      <SortOrder>1</SortOrder>
-      <Tab Alias="content/pageSettings1">Page Settings</Tab>
-      <Variations>Nothing</Variations>
-      <MandatoryMessage></MandatoryMessage>
-      <ValidationRegExpMessage></ValidationRegExpMessage>
-      <LabelOnTop>false</LabelOnTop>
-    </GenericProperty>
-    <GenericProperty>
       <Key>ea9e939a-9539-435a-b711-31e6f95b5239</Key>
       <Name>Hide In Sitemap</Name>
       <Alias>noIndex</Alias>


### PR DESCRIPTION
R1.1 - Hide breadcrumbs based on doctype set in code and not from a toggle in backoffice. Breadcrumbs will always display unless it is for a node type that is not a page.