### PR TITLE
Feature/content type query

### DIFF
--- a/Views/Partials/_Breadcrumbs.cshtml
+++ b/Views/Partials/_Breadcrumbs.cshtml
@@ -1,11 +1,8 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @using Umbraco.Cms.Core.Routing
 @using Umbraco.Extensions
-@using HelloBlake.Web.Controllers
-@inject IPublishedUrlProvider PublishedUrlProvider
 
 @{
-    PageComponents pc = new PageComponents();
     var selection = Model?.Ancestors().ToArray();
 
     if (selection?.Length > 0)
@@ -20,10 +17,10 @@
                             <ol class="breadcrumb">
                                 @foreach (var item in items)
                                 {
-                                    if (!pc.IsNodeTypeAlias(item.ContentType.Alias))
+                                    if (item.IsComposedOf("contentNodeComposition"))
                                     {
                                         <li class="breadcrumb-item">
-                                            <a href="@item.Url(PublishedUrlProvider)">@item.Name</a>
+                                            <a href="@item.Url()">@item.Name</a>
                                         </li>
                                     }
                                 }

--- a/Views/Partials/_Header.cshtml
+++ b/Views/Partials/_Header.cshtml
@@ -3,7 +3,7 @@
 @{
     var home = Model.AncestorOrSelf(1);
     // GET DEFAULT PAGES
-    var pages = home.Children.Where(x => x.IsVisible() && x.ContentType.Alias != "howToGuidePage" && x.ContentType.Alias != "blockFolder" && x.ContentType.Alias != "utilityFolder" && x.ContentType.Alias != "contentFolder" && x.ContentType.Alias != "xmlSitemap");
+    var pages = home.Children.Where(x => x.IsVisible() && x.IsComposedOf("contentNodeComposition"));
     // CHECK FOR GLOBAL SETTINGS NODE
     var utilitiesFolder = home.Children.Where(x => x.ContentType.Alias == "utilityFolder").FirstOrDefault();
     var globalSettings = utilitiesFolder != null ? utilitiesFolder.Children.Where(x => x.ContentType.Alias == "globalSettings").FirstOrDefault() : null;

--- a/Views/XMLSitemap.cshtml
+++ b/Views/XMLSitemap.cshtml
@@ -5,17 +5,7 @@
     Layout = null;
     Context.Response.ContentType = "application/xml";
     string siteDomain = String.Format("{0}://{1}", Context.Request.Scheme, Context.Request.Host);
-    var pages = Model.AncestorOrSelf(1).Descendants().Where(x =>
-        !x.Value<bool>("noIndex") 
-            && x.ContentType.Alias != "howToGuidePage"    
-            && x.ContentType.Alias != "blockFolder"
-            && x.ContentType.Alias != "utilityFolder"
-            && x.ContentType.Alias != "contentFolder"
-            && x.ContentType.Alias != "altLink" 
-            && x.ContentType.Alias != "xmlSitemap"
-            && x.GetTemplateAlias() != "parentRedirect"
-            && !string.IsNullOrEmpty(x.GetTemplateAlias())
-    );
+    var pages = Model.AncestorOrSelf(1).Descendants().Where(x => !x.Value<bool>("noIndex") && x.IsComposedOf("contentNodeComposition"));
 }
 @{
     Func<IEnumerable<IPublishedContent>, IHtmlContent> ShowTree =

--- a/uSync/v9/ContentTypes/articlepage.config
+++ b/uSync/v9/ContentTypes/articlepage.config
@@ -17,6 +17,7 @@
     <Folder>Content</Folder>
     <Compositions>
       <Composition Key="d13dac25-67eb-42e2-bc0f-8821f0dad36d">contentBlocksComposition</Composition>
+      <Composition Key="04767d85-acae-4423-8995-6e27ca02a9a5">contentNodeComposition</Composition>
       <Composition Key="c0394469-7c50-49a7-949e-280f6febee70">pageSettingsComposition</Composition>
       <Composition Key="4ad7b3f9-969f-406a-944f-e75982448e58">seoComposition</Composition>
     </Compositions>

--- a/uSync/v9/ContentTypes/blogpage.config
+++ b/uSync/v9/ContentTypes/blogpage.config
@@ -18,6 +18,7 @@
     <Compositions>
       <Composition Key="d13dac25-67eb-42e2-bc0f-8821f0dad36d">contentBlocksComposition</Composition>
       <Composition Key="8c4e650f-9275-4300-985c-cf303d372252">contentHeaderComposition</Composition>
+      <Composition Key="04767d85-acae-4423-8995-6e27ca02a9a5">contentNodeComposition</Composition>
       <Composition Key="c0394469-7c50-49a7-949e-280f6febee70">pageSettingsComposition</Composition>
       <Composition Key="4ad7b3f9-969f-406a-944f-e75982448e58">seoComposition</Composition>
     </Compositions>

--- a/uSync/v9/ContentTypes/compcontentnode.config
+++ b/uSync/v9/ContentTypes/compcontentnode.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="04767d85-acae-4423-8995-6e27ca02a9a5" Alias="compContentNode" Change="Rename" />

--- a/uSync/v9/ContentTypes/contentnodecomposition.config
+++ b/uSync/v9/ContentTypes/contentnodecomposition.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="04767d85-acae-4423-8995-6e27ca02a9a5" Alias="contentNodeComposition" Level="2">
+  <Info>
+    <Name>Content Node Composition</Name>
+    <Icon>icon-defrag</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description>Used to determine if node is content and should display in navigation lists.</Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <IsListView>False</IsListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Compositions</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties />
+  <Tabs />
+</ContentType>

--- a/uSync/v9/ContentTypes/contentpage.config
+++ b/uSync/v9/ContentTypes/contentpage.config
@@ -18,6 +18,7 @@
     <Compositions>
       <Composition Key="d13dac25-67eb-42e2-bc0f-8821f0dad36d">contentBlocksComposition</Composition>
       <Composition Key="8c4e650f-9275-4300-985c-cf303d372252">contentHeaderComposition</Composition>
+      <Composition Key="04767d85-acae-4423-8995-6e27ca02a9a5">contentNodeComposition</Composition>
       <Composition Key="c0394469-7c50-49a7-949e-280f6febee70">pageSettingsComposition</Composition>
       <Composition Key="4ad7b3f9-969f-406a-944f-e75982448e58">seoComposition</Composition>
     </Compositions>

--- a/uSync/v9/ContentTypes/home.config
+++ b/uSync/v9/ContentTypes/home.config
@@ -17,6 +17,7 @@
     <Folder>Content</Folder>
     <Compositions>
       <Composition Key="d13dac25-67eb-42e2-bc0f-8821f0dad36d">contentBlocksComposition</Composition>
+      <Composition Key="04767d85-acae-4423-8995-6e27ca02a9a5">contentNodeComposition</Composition>
       <Composition Key="4ad7b3f9-969f-406a-944f-e75982448e58">seoComposition</Composition>
     </Compositions>
     <DefaultTemplate>HomePage</DefaultTemplate>

--- a/uSync/v9/ContentTypes/searchpage.config
+++ b/uSync/v9/ContentTypes/searchpage.config
@@ -18,6 +18,7 @@
     <Compositions>
       <Composition Key="d13dac25-67eb-42e2-bc0f-8821f0dad36d">contentBlocksComposition</Composition>
       <Composition Key="8c4e650f-9275-4300-985c-cf303d372252">contentHeaderComposition</Composition>
+      <Composition Key="04767d85-acae-4423-8995-6e27ca02a9a5">contentNodeComposition</Composition>
       <Composition Key="c0394469-7c50-49a7-949e-280f6febee70">pageSettingsComposition</Composition>
       <Composition Key="4ad7b3f9-969f-406a-944f-e75982448e58">seoComposition</Composition>
     </Compositions>


### PR DESCRIPTION
Implement the Content Node Composition on document types that are used for content. This will be what is utilized to query pages that are allowed to be shown in navigation lists.